### PR TITLE
video.md: added the video format rule

### DIFF
--- a/video.md
+++ b/video.md
@@ -4,7 +4,7 @@
 
 - Platform can be anything that can run **real-time graphics!** You can have here any hardware (including iPods, oscilloscopes, LCD displays, basically anything that can produce real-time moving images) or software platforms/interpreters/emulators running on modern hardware.
 - If your demo can be run on both real hardware and on an emulator on PC, of course it is preferred to run it in a real hardware. For avoidance of doubt, all real-time rendered graphics demos that don't fit in the demo competition or the oldskool demo competition will fit here in terms of the platform.
-- The demo must be delivered in **both executable** (if possible) **and a video file** - see the file rules about allowed formats.
+- The demo must be delivered in **both executable** (if possible) **and a video file** - see the Short Film rules about allowed formats.
 - If you don't have the necessary hardware to record the video on your own, contact the organizers to set up a recording session. Do this one week prior to the party. We will be glad to help!
 - If you bring your entry to be recorded at the party place and the device/platform doesn't have an external audio output, the soundtrack of the entry must be delivered separately.
 - Demo may not last longer than **5 minutes**.
@@ -17,9 +17,9 @@
 - The demo must show in a similar manner every time executed
 - Remote entries are allowed
 
-## Short-film
+## Short Film
 
-- The production must be submitted in a supported video format.
+- The production must be submitted in a video format supported by VLC for Windows.
 - The film may not last longer than 5 minutes
 - Computer generated pieces of art (e.g. animations, machinima, ...) are preferred over plain home video types of entries. From now on, you can submit any videos of real-time generated graphics on odd devices to the Real Wild demo competition.
 - Remote entries are allowed


### PR DESCRIPTION
It turned out that the "format rules" are no more: so embedding those in these rules (VLC supported format).

Also changed the short film compo name to "Short Film" to be concise with the rest of the compo naming.