### PR TITLE
Summer '26 combined oldskool demo: finalize rules

### DIFF
--- a/summer26/oldskool.md
+++ b/summer26/oldskool.md
@@ -1,39 +1,36 @@
-## Oldskool demo combined
+## Combined oldskool demo
 
-This is a combined demo competition for Oldskool hardware in the 8-bit, 16-bit, 32-bit, and 64-bit era. The goal is to make a demo that runs on a legacy platform and shows or plays something interesting. Emulators or FPGA hardware can be used for development, but the end-product should work and be tested on real hardware. If your platform doesn't fit, consider submitting to the Real Wild compo. Feedback on the platform list is welcome with good arguments.
+This is a combined demo competition for oldskool hardware. The goal is to make a demo that runs on a legacy platform and shows or plays something interesting. Emulators or FPGA hardware can be used for development, but the end-product must work and be tested on real hardware. If your platform doesn't fit, consider submitting to the Real Wild compo. Have a platform we missed? Pitch it to us.
 
-- Demo may not last longer than **8 minutes.**
-- Demo must run on **Oldskool 8-bit & 16-bit** or **Oldskool 32-bit & 64-bit platform** (see below for details).
+- Demo must not last longer than **5 minutes.**
+- Demo must run on the **Oldskool platform** (see below) and must be tested on real hardware.
 - Demo must be launchable using the standard procedure for that platform. If in doubt, ask us.
-- No size limit, but it must be reasonable in the context of the platform.
+- No size limit, but it must be reasonable for the platform.
 - When submitting:
   - Specify the exact hardware configuration: machine type, PAL/NTSC, memory, required add-ons, SID model, etc.
-  - Provide an internet-distributable version (e.g. disk image, CD-ROM image, or ZIP with executable and data files).
-  - Provide a high-quality video capture. For example: 1920×1080 resolution at 60 Hz, using x264 in an MP4 container with a high bit rate. We may assist at the party place.
-- Capturing the entry:
-  - Preferably make your own high-bitrate capture.
-  - Emulator or FPGA capture is discouraged and should be a last resort.
-  - Ensure your entry works on real hardware.
-- For questions, contact mattip on Discord, or email: <oldskool-contact@assembly.org>.
+  - Provide an internet-distributable version (e.g. disk image, CD-ROM image, or ZIP archive with executable and data files).
+  - Provide a high-quality video capture. For example: 1920×1080 at 50 or 60 Hz, using x264 in an MP4 container with a high bit rate.
+    - Captures from emulators or FPGA-based systems should only be used as a last resort.
+  - If you cannot make the capture yourself, we may be able to help — either (1) capturing from your hardware (we're on-site Thu–Fri), or (2) providing hardware ourselves. For (2), contact us at least a week before the party; note we don't have every listed platform.
+- For questions, contact codise on Discord, or email: <oldskool-contact@assembly.org>.
 
-### Oldskool 8-bit & 16-bit platform
+### Oldskool platform
 
 - Any oldskool home computer, console, or handheld with at most a 16-bit data bus.
   - Includes up to 4th-gen consoles and 5th-gen handhelds.
   - Examples: C64, Atari 2600, VIC-20, ZX Spectrum, Amiga 500, Atari ST(e), NES, SNES, Mega Drive, Game Boy Color, etc.
-- Modern mass storage is allowed but must work from period-correct media where applicable.
-- Vintage add-ons are allowed but must be clearly stated.
-- Full FPGA systems are not allowed (submit to Real Wild). FPGA peripherals (e.g. Ultimate1541) are allowed.
-
-### Oldskool 32-bit & 64-bit platform
-
-- Any home computer, console, or handheld with a 32-bit or 64-bit CPU, with limits:
-  - Amiga/PC must run on compo machines or equivalent.
-  - Consoles: part of 5th-gen (e.g. PS1, Saturn, N64).
-  - Handhelds: similar spec to others listed (e.g. GBA, N-Gage, DS).
-  - Other platforms must be similar spec – ask for verification.
-  - Examples: Pentium 133 MHz, Amiga AGA/060, Atari Falcon, PS1, Saturn, 3DO, N64, DS.
-- Modern mass storage is allowed but must also run from period-correct media.
-- Vintage CPU turbo cards are allowed and must be declared.
-  - PC 3D accelerator cards are not allowed if they exceed compo spec.
-- Full FPGA systems are not allowed. FPGA peripherals (e.g. PSIO flash cart) are OK.
+- Or any of:
+  - Amiga: 68k (up to 060) or Cyberstorm/Blizzard PPC
+  - PC: Pentium MMX or slower
+  - Atari Falcon
+  - Mac: 68k or PPC (up to G3 233 MHz)
+  - Consoles: 5th-gen (PS1, Saturn, N64, 3DO)
+  - Handhelds: up to DS class (GBA, DS, N-Gage, GP32, GP2X F100/F200)
+- Or other oldskool platforms of similar spec or age – ask us if unsure.
+- Modern mass storage is allowed (e.g. flash carts, often FPGA-based, like 1541 Ultimate, PSIO, EverDrive).
+  - FPGA peripherals may stand in for original storage/IO, but the demo may not depend on them to enhance the host machine's speed or capabilities.
+  - The demo must use a media format compatible with the platform's original media (standard ROM size, floppy capacity, CD-ROM, etc.).
+- Period-correct add-ons are allowed but must be clearly stated.
+- Period-correct CPU turbo cards are allowed and must be clearly stated.
+- Period-correct 2D/3D accelerator cards are allowed and must be clearly stated.
+- Full FPGA systems are not allowed (submit to Real Wild).


### PR DESCRIPTION
- Merge the 8/16-bit and 32/64-bit sections into one Oldskool platform definition
- Drop runtime cap from 8 to 5 minutes
- Raise PC limit from Pentium 133 to Pentium MMX
- Add explicit handheld cap (DS class) and named 32/64-bit family caps (Mac G3 233 MHz, etc.)
- Clarify FPGA peripheral allowance and require period-compatible media format