### PR TITLE
Add summer26/rules.html for WordPress embedding

### DIFF
--- a/summer26/rules.html
+++ b/summer26/rules.html
@@ -306,37 +306,39 @@
 <h2 class="heading-element" dir="auto">Listening music</h2>
 </div>
 <p dir="auto">Refer to the General rules with the following additions:</p>
-<p dir="auto">No restrictions! Make the track you have always wanted to do with the platform of your choice.</p>
+<p dir="auto">Music centered around melody, harmony, emotion, or storytelling rather than steady dance rhythm. The focus is on musicality, composition, and expression.</p>
+<p dir="auto">Includes: Ambient, cinematic, metal, rock, classical, ballads, jazz, experimental, and hybrid styles.</p>
+<p dir="auto">Typical traits: Variable tempo and dynamics, more complex structures, not primarily rhythm-locked.</p>
 <ul dir="auto">
-     <li>All entries must be 100% original and unreleased. No covers, no remixes, no copyrighted samples or other copyrighted material.</li>
+     <li>All entries must be 100% original and unreleased. Covers and remixes are not allowed. Copyrighted samples or other copyrighted material is not allowed unless they are Creative Commons licensed.</li>
      <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
      <li>AI may not be used to compose or generate the music.</li>
      <li>You may not use any music for which you haven't acquired the rights. Most published music is controlled by Teosto/Gramex and is therefore not usable. You are liable for any infringements.</li>
      <li>There are no restrictions on composing techniques. Just make sure it's an original piece and in a supported format.</li>
      <li>Supported formats are 320kbps MP3 and FLAC.</li>
-     <li>A preselection jury will be held to comply with the time limit (typically 45 minutes).</li>
+     <li>Listening music and Dance music share a combined compo block of approximately one hour. By default, the block is split evenly between the two compos, but the final allocation may be adjusted based on preselection jury scores. One compo may therefore receive more play time than the other.</li>
      <li>Volume control (ReplayGain or similar) will be applied. Normalising the volume is recommended; loudness via excessive compression gives no advantage.</li>
-     <li>Listening Music is considered to be music that is not suited to the dance music competition.</li>
-     <li>Entry must be no longer than 3 minutes 30 seconds. Substantially exceeding this limit will result in disqualification (not fade-out)!</li>
+     <li>Entry must be no longer than 3 minutes 30 seconds. Exceeding this limit will result in disqualification.</li>
 </ul>
 <p dir="auto">Remote entries are NOT allowed for this competition.</p>
 <div class="markdown-heading" dir="auto">
 <h2 class="heading-element" dir="auto">Dance music</h2>
 </div>
 <p dir="auto">Refer to the General rules with the following additions:</p>
-<p dir="auto">Make people dance!</p>
+<p dir="auto">Music centered around rhythm and groove. The main focus is on the beat, repetition, and drive - typically intended for dancing, club environments, or rhythmic movement.</p>
+<p dir="auto">Includes: Electronic dance music, techno, house, drum &amp; bass, funk, disco, rhythmic pop, and similar styles.</p>
+<p dir="auto">Typical traits: Strong and steady beat, repetitive rhythm patterns, tempo often 100–150 BPM.</p>
+<p dir="auto">High energy alone doesn't make a song fit this category - the rhythm and groove must be central to the composition.</p>
 <ul dir="auto">
-     <li>All entries must be 100% original and unreleased. No covers, no remixes, no copyrighted samples or other copyrighted material.</li>
+     <li>All entries must be 100% original and unreleased. Covers and remixes are not allowed. Copyrighted samples or other copyrighted material is not allowed unless they are Creative Commons licensed.</li>
      <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
      <li>AI may not be used to compose or generate the music.</li>
      <li>You may not use any music for which you haven't acquired the rights. Most published music is controlled by Teosto/Gramex and is therefore not usable. You are liable for any infringements.</li>
      <li>There are no restrictions on composing techniques. Just make sure it's an original piece and in a supported format.</li>
      <li>Supported formats are 320kbps MP3 and FLAC.</li>
-     <li>A preselection jury will be held to comply with the time limit (typically 45 minutes).</li>
+     <li>Dance music and Listening music share a combined compo block of approximately one hour. By default, the block is split evenly between the two compos, but the final allocation may be adjusted based on preselection jury scores. One compo may therefore receive more play time than the other.</li>
      <li>Volume control (ReplayGain or similar) will be applied. Normalising the volume is recommended; loudness via excessive compression gives no advantage.</li>
-     <li>Your tune must have a danceable beat and character, no restrictions otherwise.</li>
-     <li>Entry must be no longer than 3 minutes 30 seconds. Substantially exceeding this limit will result in disqualification (not fade-out)!</li>
-     <li>The dance music competition might be presented as a DJ mix, where parts of your track may be crossfaded or mixed in with other compo tunes. The full track will still be released afterwards.</li>
+     <li>Entry must be no longer than 3 minutes 30 seconds. Exceeding this limit will result in disqualification.</li>
 </ul>
 <p dir="auto">Remote entries are NOT allowed for this competition.</p>
 <div class="markdown-heading" dir="auto">
@@ -345,7 +347,7 @@
 <p dir="auto">Refer to the General rules with the following additions:</p>
 <p dir="auto">Fast music competitions started off with trackers, and the entries were made with a strict time limit and the same set of samples for each contestant. Since then we've spiced things up by removing the use of samples, forcing specific chord changes, limiting the genre to italo and making people sing "Assembly 25 years" into their headphones, for example. What's in store for this year will be revealed at the party!</p>
 <ul dir="auto">
-     <li>All entries must be 100% original and unreleased. No covers, no remixes, no copyrighted samples or other copyrighted material.</li>
+     <li>All entries must be 100% original and unreleased. Covers and remixes are not allowed. Copyrighted samples or other copyrighted material is not allowed unless they are Creative Commons licensed.</li>
      <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
      <li>AI may not be used to compose or generate the music.</li>
      <li>You may not use any music for which you haven't acquired the rights. Most published music is controlled by Teosto/Gramex and is therefore not usable. You are liable for any infringements.</li>
@@ -364,7 +366,7 @@
 <p dir="auto">Refer to the General rules with the following additions:</p>
 <p dir="auto">A music competition for tracker formats (MOD, S3M, XM, IT) played in Trackmeister.</p>
 <ul dir="auto">
-     <li>All entries must be 100% original and unreleased. No covers, no remixes, no copyrighted samples or other copyrighted material.</li>
+     <li>All entries must be 100% original and unreleased. Covers and remixes are not allowed. Copyrighted samples or other copyrighted material is not allowed unless they are Creative Commons licensed.</li>
      <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
      <li>AI may not be used to compose or generate the music.</li>
      <li>You may not use any music for which you haven't acquired the rights. Most published music is controlled by Teosto/Gramex and is therefore not usable. You are liable for any infringements.</li>
@@ -389,7 +391,7 @@
 <p dir="auto">Refer to the General rules with the following additions:</p>
 <p dir="auto">A music competition for chip music on legacy hardware platforms.</p>
 <ul dir="auto">
-     <li>All entries must be 100% original and unreleased. No covers, no remixes, no copyrighted samples or other copyrighted material.</li>
+     <li>All entries must be 100% original and unreleased. Covers and remixes are not allowed. Copyrighted samples or other copyrighted material is not allowed unless they are Creative Commons licensed.</li>
      <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
      <li>AI may not be used to compose or generate the music.</li>
      <li>You may not use any music for which you haven't acquired the rights. Most published music is controlled by Teosto/Gramex and is therefore not usable. You are liable for any infringements.</li>

--- a/summer26/rules.html
+++ b/summer26/rules.html
@@ -1,0 +1,542 @@
+<div class="markdown-heading" dir="auto">
+<h1 class="heading-element" dir="auto">General rules</h1>
+</div>
+<p dir="auto">These general rules apply to all competitions. Compo-specific rules override them where applicable. If in doubt, contact CompoCrew.</p>
+<ul dir="auto">
+     <li>
+<p dir="auto">Entries must be uploaded to the competition system before the deadline. All deadlines are hard - contact the organizer if you're stuck.</p>
+</li>
+     <li>
+<p dir="auto">Whether remote entries are allowed depends on the specific competition's rules. A ticket is not required for a remote entry but is required to vote.</p>
+</li>
+     <li>
+<p dir="auto">The author or designated proxy must be present at the party to receive prizes. A valid IBAN is required for money prizes.</p>
+</li>
+     <li>
+<p dir="auto">Submitting an entry means accepting the competition contract.</p>
+</li>
+     <li>
+<p dir="auto">Maximum one entry per artist per competition. If you submit multiple, only one will be accepted.</p>
+</li>
+     <li>
+<p dir="auto">AI-generated content is not allowed in any competition unless that competition's rules explicitly permit it.</p>
+</li>
+     <li>
+<p dir="auto">You must own or have permission for all material in your entry - burden of proof is on you. See the copyright FAQ. No trademarked or copyrighted content (logos, etc.). Finnish copyright law has no "fair use".</p>
+</li>
+     <li>
+<p dir="auto">Fan art using copyrighted characters or works is not allowed. With money prizes at stake this is enforced strictly.</p>
+</li>
+     <li>
+<p dir="auto">Shown entries are preselected by jury / organizers. Entries that aren't shown are not released by Assembly.</p>
+</li>
+     <li>
+<p dir="auto">Organizers may disqualify explicit, racist, or disturbing material, modify rules to clarify ambiguities, or change prizes (especially if entry quality or number is low).</p>
+</li>
+</ul>
+&nbsp;
+<div class="markdown-heading" dir="auto">
+<h1 class="heading-element" dir="auto">Realtime</h1>
+</div>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Demo</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<ul dir="auto">
+     <li>All material in an entry must be previously unreleased. Realtime/development entries may include music and graphics that compete in the same event's compos.</li>
+     <li>Previously released components (e.g. fonts, system samples) are OK only if they are not the main effort and you have rights to use them.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI-generated content is not allowed in this compo.</li>
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>Entry must be in an <strong>executable form</strong>. Pure animation files are not allowed - executables that only include an animation and an animation player will not be accepted.</li>
+     <li>The production must work from <strong>read-only media</strong> and must not modify system settings (for example: Windows registry). However, you may use the platform's standard temporary directory during the execution of your entry for storing data, if such a service is available.</li>
+     <li>The production must show in a similar manner every time it is executed.</li>
+     <li>Entries which cannot be run on the compo machines will be disqualified. To prevent this, you can ask us to test your production on the compo machines. Do this early so you have time to fix any problems.</li>
+     <li>A <strong>screenshot</strong> image must be submitted with the entry to the competition management system.</li>
+     <li>You must hide the <strong>mouse cursor</strong>.</li>
+     <li>Entries will be recorded at 1080p60 (or possibly 1080p50) resolution.</li>
+     <li>Demo may not last longer than <strong>8 minutes.</strong></li>
+     <li>2 GB size limit for the compressed archive.</li>
+     <li>Entry must run on a <strong>Desktop platform.</strong></li>
+     <li>The user must be able to exit at any time by pressing a key. On PC, this key must be ESC.</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">4K Intro</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<ul dir="auto">
+     <li>All material in an entry must be previously unreleased. Realtime/development entries may include music and graphics that compete in the same event's compos.</li>
+     <li>Previously released components (e.g. fonts, system samples) are OK only if they are not the main effort and you have rights to use them.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI-generated content is not allowed in this compo.</li>
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>Entry must be in an <strong>executable form</strong>. Pure animation files are not allowed.</li>
+     <li>The production must work from <strong>read-only media</strong> and must not modify system settings.</li>
+     <li>The production must show in a similar manner every time it is executed.</li>
+     <li>Entries which cannot be run on the compo machines will be disqualified.</li>
+     <li>A <strong>screenshot</strong> image must be submitted with the entry.</li>
+     <li>You must hide the <strong>mouse cursor</strong>.</li>
+     <li>Entries will be recorded at 1080p60 (or possibly 1080p50) resolution.</li>
+     <li>Maximum size in executable form is <strong>4096 bytes.</strong></li>
+     <li>Intro may not last longer than <strong>5 minutes.</strong></li>
+     <li>The production must be a <em>single file</em>. Additional info files are fine but will be deleted prior to running the intro.</li>
+     <li>Entry must run on a <strong>Desktop platform.</strong></li>
+     <li>The user must be able to exit at any time by pressing a key. On PC, this key must be ESC.</li>
+     <li>For Oldskool platforms, submit to the Combined Oldskool compo instead.</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Beginner Demo</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<p dir="auto">This competition is only for beginners. Remember that this competition is more about taking part, learning, and cheering for everyone than taking it too seriously!</p>
+<ul dir="auto">
+     <li>All material in an entry must be previously unreleased. Realtime/development entries may include music and graphics that compete in the same event's compos.</li>
+     <li>Previously released components (e.g. fonts, system samples) are OK only if they are not the main effort and you have rights to use them.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI-generated content is not allowed in this compo.</li>
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>Entry must be in an <strong>executable form</strong>. Pure animation files are not allowed.</li>
+     <li>The production must work from <strong>read-only media</strong> and must not modify system settings.</li>
+     <li>The production must show in a similar manner every time it is executed.</li>
+     <li>Entries which cannot be run on the compo machines will be disqualified.</li>
+     <li>A <strong>screenshot</strong> image must be submitted with the entry.</li>
+     <li>You must hide the <strong>mouse cursor</strong>.</li>
+     <li>Entries will be recorded at 1080p60 (or possibly 1080p50) resolution.</li>
+     <li>Demo may not last longer than <strong>8 minutes.</strong></li>
+     <li>Entry must run on a <strong>Desktop platform.</strong></li>
+     <li>The user must be able to exit at any time by pressing a key. On PC, this key must be ESC.</li>
+     <li>The creator(s) must be beginners in demo making and must either:
+<ul dir="auto">
+     <li>Not have previously published any demos (procedural art) at demo parties. Groups must have a previously unused name to prevent name bias in voting ("namevoting"), <strong>OR</strong></li>
+     <li>Have previously participated only in Assembly beginner competitions without receiving prizes.</li>
+</ul>
+</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">One Minute Demo</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<p dir="auto">A demo with a hard 1-minute time limit. Especially intended for newcomers but open to everyone. Keep it short, focused, and fun. (This compo was previously known as "One Scene".)</p>
+<ul dir="auto">
+     <li>All material in an entry must be previously unreleased. Realtime/development entries may include music and graphics that compete in the same event's compos.</li>
+     <li>Previously released components (e.g. fonts, system samples) are OK only if they are not the main effort and you have rights to use them.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI-generated content is not allowed in this compo.</li>
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>Entry must be in an <strong>executable form</strong>. Pure animation files are not allowed.</li>
+     <li>The production must work from <strong>read-only media</strong> and must not modify system settings.</li>
+     <li>The production must show in a similar manner every time it is executed.</li>
+     <li>Entries which cannot be run on the compo machines will be disqualified.</li>
+     <li>A <strong>screenshot</strong> image must be submitted with the entry.</li>
+     <li>You must hide the <strong>mouse cursor</strong>.</li>
+     <li>Entries will be recorded at 1080p60 (or possibly 1080p50) resolution.</li>
+     <li>The demo will be shown for at most <strong>1 minute</strong>. It may either loop or finish at any time before the 1-minute maximum running time.</li>
+     <li>Entry must run on a <strong>Desktop platform.</strong></li>
+     <li>The user must be able to exit at any time by pressing a key. On PC, this key must be ESC.</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Combined Oldskool demo</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<p dir="auto">This is a combined demo competition for oldskool hardware. The goal is to make a demo that runs on a legacy platform and shows or plays something interesting. Emulators or FPGA hardware can be used for development, but the end-product must work and be tested on real hardware. If your platform doesn't fit, consider submitting to the Real Wild compo. Have a platform we missed? Pitch it to us.</p>
+<ul dir="auto">
+     <li>All material in an entry must be previously unreleased. Realtime/development entries may include music and graphics that compete in the same event's compos.</li>
+     <li>Previously released components (e.g. fonts, system samples) are OK only if they are not the main effort and you have rights to use them.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI-generated content is not allowed in this compo.</li>
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>Entry must be in an <strong>executable form</strong>. Pure animation files are not allowed.</li>
+     <li>The production must show in a similar manner every time it is executed.</li>
+     <li>A <strong>screenshot</strong> image must be submitted with the entry.</li>
+     <li>Entries will be recorded at 1080p60 (or possibly 1080p50) resolution.</li>
+     <li>Demo must not last longer than <strong>5 minutes.</strong></li>
+     <li>Demo must run on the <strong>Oldskool platform</strong> (see below) and must be tested on real hardware.</li>
+     <li>Demo must be launchable using the standard procedure for that platform. If in doubt, ask us.</li>
+     <li>No size limit, but it must be reasonable for the platform.</li>
+     <li>When submitting:
+<ul dir="auto">
+     <li>Specify the exact hardware configuration: machine type, PAL/NTSC, memory, required add-ons, SID model, etc.</li>
+     <li>Provide an internet-distributable version (e.g. disk image, CD-ROM image, or ZIP archive with executable and data files).</li>
+     <li>Provide a high-quality video capture. For example: 1920×1080 at 50 or 60 Hz, using x264 in an MP4 container with a high bit rate.
+<ul dir="auto">
+     <li>Captures from emulators or FPGA-based systems should only be used as a last resort.</li>
+</ul>
+</li>
+     <li>If you cannot make the capture yourself, we may be able to help - either (1) capturing from your hardware (we're on-site Thu–Fri), or (2) providing hardware ourselves. For (2), contact us at least a week before the party; note we don't have every listed platform.</li>
+</ul>
+</li>
+     <li>For questions, contact codise on Discord, or email: &lt;<a href="mailto:oldskool-contact@assembly.org">oldskool-contact@assembly.org</a>&gt;.</li>
+</ul>
+<div class="markdown-heading" dir="auto">
+<h3 class="heading-element" dir="auto">Oldskool platform</h3>
+</div>
+<ul dir="auto">
+     <li>Any oldskool home computer, console, or handheld with at most a 16-bit data bus.
+<ul dir="auto">
+     <li>Includes up to 4th-gen consoles and 5th-gen handhelds.</li>
+     <li>Examples: C64, Atari 2600, VIC-20, ZX Spectrum, Amiga 500, Atari ST(e), NES, SNES, Mega Drive, Game Boy Color, etc.</li>
+</ul>
+</li>
+     <li>Or any of:
+<ul dir="auto">
+     <li>Amiga: 68k (up to 060) or Cyberstorm/Blizzard PPC</li>
+     <li>PC: Pentium MMX or slower</li>
+     <li>Atari Falcon</li>
+     <li>Mac: 68k or PPC (up to G3 233 MHz)</li>
+     <li>Consoles: 5th-gen (PS1, Saturn, N64, 3DO)</li>
+     <li>Handhelds: up to DS class (GBA, DS, N-Gage, GP32, GP2X F100/F200)</li>
+</ul>
+</li>
+     <li>Or other oldskool platforms of similar spec or age – ask us if unsure.</li>
+     <li>Modern mass storage is allowed (e.g. flash carts, often FPGA-based, like 1541 Ultimate, PSIO, EverDrive).
+<ul dir="auto">
+     <li>FPGA peripherals may stand in for original storage/IO, but the demo may not depend on them to enhance the host machine's speed or capabilities.</li>
+     <li>The demo must use a media format compatible with the platform's original media (standard ROM size, floppy capacity, CD-ROM, etc.).</li>
+</ul>
+</li>
+     <li>Period-correct add-ons are allowed but must be clearly stated.</li>
+     <li>Period-correct CPU turbo cards are allowed and must be clearly stated.</li>
+     <li>Period-correct 2D/3D accelerator cards are allowed and must be clearly stated.</li>
+     <li>Full FPGA systems are not allowed (submit to Real Wild).</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Fantasy Console</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<ul dir="auto">
+     <li>All material in an entry must be previously unreleased. Realtime/development entries may include music and graphics that compete in the same event's compos.</li>
+     <li>Previously released components (e.g. fonts, system samples) are OK only if they are not the main effort and you have rights to use them.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI-generated content is not allowed in this compo.</li>
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>Entry must be in an <strong>executable form</strong>.</li>
+     <li>The production must show in a similar manner every time it is executed.</li>
+     <li>A <strong>screenshot</strong> image must be submitted with the entry.</li>
+     <li>Entries will be recorded at 1080p60 (or possibly 1080p50) resolution.</li>
+     <li>Allowed platforms include but are not limited to: TIC-80, PICO-8, PICOTRON, Quadplay, Voxatron, MicroW8, and IBNIZ. Ask for verification on other platforms.</li>
+     <li>Entry can run on multiple cartridges (specify size in notes).</li>
+     <li>Production may not last longer than <strong>5 minutes</strong>.</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Game Development</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<ul dir="auto">
+     <li>All material in an entry must be previously unreleased. Realtime/development entries may include music and graphics that compete in the same event's compos.</li>
+     <li>Previously released components (e.g. fonts, system samples) are OK only if they are not the main effort and you have rights to use them.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI-generated content is not allowed in this compo.</li>
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>All entries must be previously unreleased (no Game Jams, Steam/App Store pages, trailers, etc.).</li>
+     <li>Entry must run on a <strong>Desktop, Oldskool, or Mobile platform.</strong></li>
+     <li>Presentation:
+<ul dir="auto">
+     <li>Max <strong>3 minutes</strong> showing time (game itself can be longer).</li>
+     <li>Recommended: submit a presentation video in MP4 format with H.264 or H.265 compression.</li>
+</ul>
+</li>
+     <li>The game must be <strong>playable!</strong></li>
+     <li>Must allow exiting at any time (e.g. ESC or menu).</li>
+     <li>The game may write settings/saves/high scores to disk/registry.</li>
+     <li>May use network connections.</li>
+     <li>PC version must support <strong>1080p resolution</strong>.</li>
+     <li>Submit a <strong>screenshot</strong> along with the entry.</li>
+     <li>Multi-platform support allowed (Windows, Java, Linux, Mac, 3DS, Android, iOS, etc.).</li>
+     <li>For Oldskool entries, see Combined Oldskool compo rules.</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">AI Coding (Vibe Demo)</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<p dir="auto">Other competitions do not allow AI-generated content. This one does - AI tools may be used to write up to 100% of the code. Use as much or as little AI as you want. Other assets (music, graphics) can be human-made or AI-generated as you choose. The result must be an executable real-time production, not a single-shot prompt output.</p>
+<ul dir="auto">
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>AI use in code is welcome - anywhere from a little assistance to fully AI-written.</li>
+     <li>The entry must be an <strong>executable real-time production</strong>. Any platform (Desktop, oldskool, fantasy console, etc.) is welcome.</li>
+     <li>Entries may not exceed 5 minutes in length.</li>
+     <li>Submit the executable. A 1080p video capture is also required - the video is what gets shown on screen, but the executable must be there too so we can verify it runs.</li>
+     <li>The size of the entry must be reasonable and can be delivered via USB stick or through Partyman.</li>
+     <li>Submit a <code>readme.txt</code> describing the AI tools used.</li>
+     <li>A <strong>screenshot</strong> image must be submitted with the entry.</li>
+     <li>The production must show in a similar manner every time it is executed.</li>
+     <li>You must hide the <strong>mouse cursor</strong>.</li>
+     <li>Entries will be recorded at 1080p60 (or possibly 1080p50) resolution.</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Real Wild</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<ul dir="auto">
+     <li>All material in an entry must be previously unreleased.</li>
+     <li>Previously released components (e.g. fonts, system samples) are OK only if they are not the main effort and you have rights to use them.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI-generated content is not allowed in this compo.</li>
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>A <strong>screenshot</strong> image must be submitted with the entry.</li>
+     <li>Pure animation files are not allowed in real-time competitions. Executables that only include an animation and an animation player will not be accepted.</li>
+     <li>Platform can be anything that can run <strong>real-time graphics!</strong> This includes any hardware (e.g. iPods, oscilloscopes, LCD displays) or software platforms/interpreters/emulators running on modern hardware.</li>
+     <li>If your demo can be run on both real hardware and an emulator on PC, it is preferred to run it on real hardware. For avoidance of doubt, all real-time rendered graphics demos that don't fit in the demo competition or the Combined Oldskool demo competition will fit here in terms of platform.</li>
+     <li>The demo must be delivered in <strong>both executable</strong> (if possible) <strong>and a video file</strong> – see the Short Film rules about allowed formats.</li>
+     <li>If you don't have the necessary hardware to record the video on your own, contact the organizers to set up a recording session. Do this one week prior to the party. We will be glad to help!</li>
+     <li>If you bring your entry to be recorded at the party place and the device/platform doesn't have an external audio output, the soundtrack of the entry must be delivered separately.</li>
+     <li>Demo may not last longer than <strong>5 minutes</strong>.</li>
+     <li>Hardware and/or components must have been previously released (no unreleased R&amp;D hardware).</li>
+     <li>You must provide specific instructions to build, configure, install, and run the entry on the platform. If the platform/device is your own specific hack, the <strong>instructions</strong> to do such a hardware hack must be included.</li>
+     <li>To prove your entry really runs on the platform, you must either:
+<ul dir="auto">
+     <li><strong>bring the hardware to the party place</strong> and show your demo to the organizers / the jury, or</li>
+     <li><strong>in case of remote entries</strong>, record a proof video if the actual competition video does not provide enough proof. Organizers/jury will judge the proof. If in doubt, contact the organizers.</li>
+</ul>
+</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+&nbsp;
+<div class="markdown-heading" dir="auto">
+<h1 class="heading-element" dir="auto">Music</h1>
+</div>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Listening music</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<p dir="auto">No restrictions! Make the track you have always wanted to do with the platform of your choice.</p>
+<ul dir="auto">
+     <li>All entries must be 100% original and unreleased. No covers, no remixes, no copyrighted samples or other copyrighted material.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI may not be used to compose or generate the music.</li>
+     <li>You may not use any music for which you haven't acquired the rights. Most published music is controlled by Teosto/Gramex and is therefore not usable. You are liable for any infringements.</li>
+     <li>There are no restrictions on composing techniques. Just make sure it's an original piece and in a supported format.</li>
+     <li>Supported formats are 320kbps MP3 and FLAC.</li>
+     <li>A preselection jury will be held to comply with the time limit (typically 45 minutes).</li>
+     <li>Volume control (ReplayGain or similar) will be applied. Normalising the volume is recommended; loudness via excessive compression gives no advantage.</li>
+     <li>Listening Music is considered to be music that is not suited to the dance music competition.</li>
+     <li>Entry must be no longer than 3 minutes 30 seconds. Substantially exceeding this limit will result in disqualification (not fade-out)!</li>
+</ul>
+<p dir="auto">Remote entries are NOT allowed for this competition.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Dance music</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<p dir="auto">Make people dance!</p>
+<ul dir="auto">
+     <li>All entries must be 100% original and unreleased. No covers, no remixes, no copyrighted samples or other copyrighted material.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI may not be used to compose or generate the music.</li>
+     <li>You may not use any music for which you haven't acquired the rights. Most published music is controlled by Teosto/Gramex and is therefore not usable. You are liable for any infringements.</li>
+     <li>There are no restrictions on composing techniques. Just make sure it's an original piece and in a supported format.</li>
+     <li>Supported formats are 320kbps MP3 and FLAC.</li>
+     <li>A preselection jury will be held to comply with the time limit (typically 45 minutes).</li>
+     <li>Volume control (ReplayGain or similar) will be applied. Normalising the volume is recommended; loudness via excessive compression gives no advantage.</li>
+     <li>Your tune must have a danceable beat and character, no restrictions otherwise.</li>
+     <li>Entry must be no longer than 3 minutes 30 seconds. Substantially exceeding this limit will result in disqualification (not fade-out)!</li>
+     <li>The dance music competition might be presented as a DJ mix, where parts of your track may be crossfaded or mixed in with other compo tunes. The full track will still be released afterwards.</li>
+</ul>
+<p dir="auto">Remote entries are NOT allowed for this competition.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Fast music</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<p dir="auto">Fast music competitions started off with trackers, and the entries were made with a strict time limit and the same set of samples for each contestant. Since then we've spiced things up by removing the use of samples, forcing specific chord changes, limiting the genre to italo and making people sing "Assembly 25 years" into their headphones, for example. What's in store for this year will be revealed at the party!</p>
+<ul dir="auto">
+     <li>All entries must be 100% original and unreleased. No covers, no remixes, no copyrighted samples or other copyrighted material.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI may not be used to compose or generate the music.</li>
+     <li>You may not use any music for which you haven't acquired the rights. Most published music is controlled by Teosto/Gramex and is therefore not usable. You are liable for any infringements.</li>
+     <li>Supported formats are 320kbps MP3 and FLAC.</li>
+     <li>A preselection jury will be held to comply with the time limit (typically 45 minutes).</li>
+     <li>Volume control (ReplayGain or similar) will be applied. Normalising the volume is recommended; loudness via excessive compression gives no advantage.</li>
+     <li>Fast Music is created at the party with additional rules and restrictions that will be revealed 1.5 hours before the deadline.</li>
+     <li>Entry must be no longer than 3 minutes 30 seconds (3:30).</li>
+     <li>No software restrictions (usually).</li>
+     <li>Submit the finished tune into the compo system before the competition deadline.</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Tracked Music</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<p dir="auto">A music competition for tracker formats (MOD, S3M, XM, IT) played in Trackmeister.</p>
+<ul dir="auto">
+     <li>All entries must be 100% original and unreleased. No covers, no remixes, no copyrighted samples or other copyrighted material.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI may not be used to compose or generate the music.</li>
+     <li>You may not use any music for which you haven't acquired the rights. Most published music is controlled by Teosto/Gramex and is therefore not usable. You are liable for any infringements.</li>
+     <li>A preselection jury will be held to comply with the time limit (typically 45 minutes).</li>
+     <li>Volume control (ReplayGain or similar) will be applied. Normalising the volume is recommended; loudness via excessive compression gives no advantage.</li>
+     <li>Maximum size: 1 MB (1,048,576 bytes)</li>
+     <li>Maximum length: 3 minutes. If your song is longer, it will be faded out after 3 minutes.</li>
+     <li>Maximum amount of channels you can use is eight (8).</li>
+     <li>If your song loops, it will be faded out after the first loop.</li>
+     <li>Entries will be played in Trackmeister with the following settings:
+<ul dir="auto">
+     <li>MOD: No Interpolation, No Ramping, 50% Stereo Separation, normal MOD playback mode.</li>
+     <li>S3M/XM/IT: Sinc Interpolation, Sensitive Ramping, 50% Stereo Separation.</li>
+</ul>
+</li>
+     <li>Please provide a recording of your entry in 320kbps MP3 or FLAC in addition to the tracker file (for streaming and voting).</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Oldskool Music</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<p dir="auto">A music competition for chip music on legacy hardware platforms.</p>
+<ul dir="auto">
+     <li>All entries must be 100% original and unreleased. No covers, no remixes, no copyrighted samples or other copyrighted material.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI may not be used to compose or generate the music.</li>
+     <li>You may not use any music for which you haven't acquired the rights. Most published music is controlled by Teosto/Gramex and is therefore not usable. You are liable for any infringements.</li>
+     <li>Supported formats for the recording are 320kbps MP3 and FLAC.</li>
+     <li>A preselection jury will be held to comply with the time limit (typically 45 minutes).</li>
+     <li>Volume control (ReplayGain or similar) will be applied. Normalising the volume is recommended; loudness via excessive compression gives no advantage.</li>
+     <li>Maximum size: 64 KB (65,536 bytes)</li>
+     <li>Maximum length: 3 minutes. If your song is longer, it will be faded out after 3 minutes.</li>
+     <li>Maximum pre-calculation time: 30 seconds.</li>
+     <li>Entries may not loop and have to end with silence.</li>
+     <li>Screen contents will not be displayed so don't waste your time creating fancy effects.</li>
+     <li>Allowed platforms: Commodore 64, Sega Master System, Sega Mega Drive, Super Nintendo, Atari ST, Atari 8bit, ZX Spectrum 48k / 128k, MS-DOS (AdLib/OPL), Game Boy, and NES.</li>
+     <li>The entry must also be delivered as an executable program or a recognized standard file format (such as .SID, .VGM, .PRG) that can be played on the target platform.</li>
+     <li>YOU NEED TO PROVIDE US A RECORDING OF YOUR ENTRY FROM REAL HARDWARE in MP3 (256kbps or higher), OGG (256kbps or higher), WAV, or FLAC format.</li>
+     <li>For Commodore 64 entries, please inform the audience which SID Chip was used (6581 or 8580) on the submission form!</li>
+     <li>Standard Tracked Music (MOD, S3M, XM, IT) belongs in the Tracked Music competition.</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+&nbsp;
+<div class="markdown-heading" dir="auto">
+<h1 class="heading-element" dir="auto">Graphics</h1>
+</div>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Digital Graphics</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<ul dir="auto">
+     <li>All entries must be original and unreleased. No covers, copies, or reproductions of someone else's work.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI-generated content is not allowed in this compo.</li>
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>The only supported image formats are PNG and JPG. Only RGB colour space allowed – no CMYK images.</li>
+     <li>If the original image was in vector format, you may include the image in the submission package also in SVG format. However, the PNG or JPEG image will be the primary submission and will be shown on the big screen.</li>
+     <li>Pictures will be shown in 1920x1080 resolution with full 24-bit color depth.</li>
+     <li>Submit a version of the final image with NO visible signature. Name this file with "_nosig" prefix (e.g. "cool_image.png" for the final image and "cool_image_nosig.png" for unsigned version of the same image). Entries without an unsigned version will be disqualified.</li>
+     <li>A text file named "readme.txt" stating used techniques and sources of any material used in the entry must be submitted.</li>
+     <li><strong>The entry must be a digital image, with the bulk of the artistic work done in digital tools.</strong> A scan of a finished painting or drawing on its own does not qualify - but scanned material may be used as a base, reference, or element if you build on top of it digitally.</li>
+     <li><strong>Submit your work to the right compo.</strong> Digital Graphics is for digital painting, digital illustration, vector art, and mixed digital work. If your entry is <em>primarily</em> one of the following, submit it to that compo instead:
+<ul dir="auto">
+     <li><strong>Pixel &amp; Oldskool Graphics</strong> - pixel-by-pixel work in low resolution, or native legacy platform formats (C64, Amiga IFF, etc.)</li>
+     <li><strong>3D Graphics</strong> - work whose main artistic effort is 3D modeling and rendering</li>
+</ul>
+</li>
+     <li>The image resolution must be 1920x1080. Feel free to make the image 1080x1920, but due to the letterboxing, it will appear smaller on screen and in the stream as well.</li>
+     <li>You must submit clear evidence of the process of creating the digital graphics competition picture in the form of at least THREE versions of the unfinished picture that show the creation process.</li>
+     <li>This means that the different steps of the process (e.g. outline, coloring, retouching) are shown in different files from different points in time when the picture is being created.</li>
+     <li>Order the unfinished stages of the picture by renaming the files with appropriate prefixes (f.i. "stage1.png", "stage2.png") and put them into a subdirectory called "unfinished" in the ZIP archive.</li>
+     <li>Write the techniques used in the PMS while submitting the image, maximum of 5 words (i.e. "digital painting", "completely vector based", "Composition of multiple methods").</li>
+     <li>You may also include the image in source or vector format in the submission package, if the size of the package does not exceed 10 MB.</li>
+     <li>While you are allowed to use stock photos in your entry, clearly the major part of the entry must be the result of your own creativity. Use only stock photos you have the rights to.</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Pixel &amp; Oldskool Graphics</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<p dir="auto">A combined graphics competition for traditional pixeled graphics and legacy platform native formats. Submit your work as either a modern pixeled image or in a native legacy format.</p>
+<ul dir="auto">
+     <li>All entries must be original and unreleased. No covers, copies, or reproductions of someone else's work.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI-generated content is not allowed in this compo.</li>
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>Entries will be shown (proportionally scaled) on a 16:9 screen.</li>
+     <li>Use of stock photos, paintover, etc. techniques is NOT ALLOWED in this competition.</li>
+     <li>Entries without an unsigned final picture will be disqualified.</li>
+</ul>
+<div class="markdown-heading" dir="auto">
+<h3 class="heading-element" dir="auto">Modern pixeled graphics</h3>
+</div>
+<p dir="auto">This is an oldschool pixeled graphics competition. It means that we're expecting to see entries that have been drawn pixel by pixel, by using old-fashioned techniques and not, for example, overpainting renders, repainting or using photos as parts of the picture. If something in the picture seems to be out of place, it might not make it to be presented on the big screen.</p>
+<ul dir="auto">
+     <li>The image resolution should be appropriate for pixel art - e.g. 320x240, 320x200, 256x192, 160x200, or other platform-native low-res size. 256 colors max.</li>
+     <li>Submit as PNG. No animation.</li>
+     <li>Submit the final image with NO visible signature, using "_nosig" prefix (e.g. "cool_image_nosig.png"). Entries without an unsigned version will be disqualified. You may optionally include a signed version too.</li>
+     <li>Submit at least three (3) intermediate stages showing the process of pixeling. Name them with appropriate prefixes (e.g. "stage1.png", "stage2.png") and put them in an "unfinished" subdirectory in the ZIP archive.</li>
+</ul>
+<div class="markdown-heading" dir="auto">
+<h3 class="heading-element" dir="auto">Legacy platform native formats</h3>
+</div>
+<p dir="auto">This is a graphics competition for legacy platforms in their native formats - C64 multicolor, Amiga IFF, Atari ST, ZX Spectrum, NES, etc. The goal is to create artwork that respects the constraints of the original hardware (color palette, resolution, native format).</p>
+<ul dir="auto">
+     <li>Entry must be created on a native format for the target platform (e.g. C64 multicolor, Amiga IFF/LBM, Atari ST .PI1/.NEO, ZX Spectrum .SCR).</li>
+     <li>Specify the platform and source format clearly in submission notes.</li>
+     <li>Submit:
+<ul dir="auto">
+     <li>The native source file</li>
+     <li>A converted PNG version (same resolution, original palette preserved) for big-screen display</li>
+     <li>A <code>_nosig</code> version without signature</li>
+</ul>
+</li>
+     <li>Submit a <code>readme.txt</code> stating the platform, native format, tools used, and creation process.</li>
+</ul>
+<p dir="auto">If you have questions or wish to have a clarification on the rules, please contact your friendly scene lounge organizers well before the competition! Happy pixeling &lt;3</p>
+<p dir="auto">Remote entries are welcome.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">3D Graphics</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<p dir="auto">This competition is for 3D-rendered still images. Use any tool you like (Blender, Maya, Cinema 4D, etc.) - submit the final rendered image.</p>
+<ul dir="auto">
+     <li>All scene content must be original and unreleased. No covers, copies, or reproductions of someone else's work.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI-generated content is not allowed in this compo.</li>
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>The only supported image formats are PNG and JPG. Only RGB colour space allowed – no CMYK images.</li>
+     <li>Pictures will be shown in 1920x1080 resolution with full 24-bit color depth.</li>
+     <li>Submit a version of the final image with NO visible signature. Name this file with "_nosig" prefix. Entries without an unsigned version will be disqualified.</li>
+     <li>Image resolution: 1920x1080</li>
+     <li>Mesh has to be unpublished before the competition deadline</li>
+     <li>Submit a <code>readme.txt</code> listing tools used and creation process</li>
+     <li>Optionally include source files (Blender, FBX, etc.) under 50 MB</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Fast Graphics</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<ul dir="auto">
+     <li>All entries must be original and unreleased. No covers, copies, or reproductions of someone else's work.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI-generated content is not allowed in this compo.</li>
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>The only supported image formats are PNG and JPG. Only RGB colour space allowed – no CMYK images.</li>
+     <li>Pictures will be shown in 1920x1080 resolution with full 24-bit color depth.</li>
+     <li>Submit a version of the final image with NO visible signature. Name this file with "_nosig" prefix. Entries without an unsigned version will be disqualified.</li>
+     <li>The image resolution must be 1920x1080.</li>
+     <li>You have 1.5 hours to complete your picture. Submit the finished picture by the competition deadline.</li>
+     <li>Your picture must adhere to the theme and contain a specific graphical element. Both will be announced via Partyman (scene.assembly.org) and on the Assembly website at the start of the 1.5-hour compo time.</li>
+     <li>No intermediate stages are required.</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>
+&nbsp;
+<div class="markdown-heading" dir="auto">
+<h1 class="heading-element" dir="auto">Video</h1>
+</div>
+<div class="markdown-heading" dir="auto">
+<h2 class="heading-element" dir="auto">Short Film</h2>
+</div>
+<p dir="auto">Refer to the General rules with the following additions:</p>
+<ul dir="auto">
+     <li>The film must be original and unreleased.</li>
+     <li>If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
+     <li>AI-generated content is not allowed in this compo.</li>
+     <li>Fan art using copyrighted characters or works is not allowed.</li>
+     <li>The production must be submitted in a video format supported by VLC for Windows.</li>
+     <li>The film may not last longer than <strong>5 minutes</strong>.</li>
+     <li>Computer-generated pieces of art (e.g. animations, machinima, etc.) are preferred over plain home video types of entries.</li>
+     <li>Videos of real-time generated graphics on odd devices belong in the Real Wild demo competition.</li>
+</ul>
+<p dir="auto">Remote entries are welcome.</p>


### PR DESCRIPTION
## Summary

Combines all `summer26/` rule files into a single HTML page (`summer26/rules.html`) that can be pasted into the Assembly WordPress page (S26 demoscene competition rules).

Markup mirrors the S25 page: `<div class="markdown-heading">` wrappers around `<h1>` (top sections), `<h2>` (compos), `<h3>` (sub-sections), `<p dir="auto">` paragraphs and `<ul dir="auto">` lists. The ez-toc plugin generates the table of contents from the headings automatically.

## Structure

- `<h1>` General rules
- `<h1>` Realtime — Demo, 4K Intro, Beginner Demo, One Minute Demo, Combined Oldskool (+ `<h3>` Oldskool platform), Fantasy Console, Game Development, AI Coding (Vibe Demo), Real Wild
- `<h1>` Music — Listening, Dance, Fast, Tracked, Oldskool
- `<h1>` Graphics — Digital, Pixel & Oldskool (+ `<h3>` Modern pixeled + `<h3>` Legacy native), 3D, Fast
- `<h1>` Video — Short Film

## Design decision: repetition over factoring

Per-compo rule lists keep the **full** text from each `.md` file — the common bits ("AI not allowed", "previously unreleased", "screenshot required", etc.) are repeated under every compo. The S25 page factored these into "General realtime/music rules" sections, but the choice for S26 is to **repeat**, because attendees don't read the general section.

## Open PRs not included

- #33 (CC clarification across 5 music compos) — if merged, regenerate this file
- #34 (Dance + Listening combined block + style definitions) — if merged, regenerate this file

## Test plan

- [ ] Paste the HTML into the WP page Code editor and verify rendering
- [ ] Verify ez-toc TOC auto-generates correctly from h1/h2/h3
- [ ] Spot-check a few compos against their `.md` source