### PR TITLE
Clarify Digital Graphics vs 3D Graphics boundary

### DIFF
--- a/summer26/graphics/3d-graphics.md
+++ b/summer26/graphics/3d-graphics.md
@@ -2,7 +2,7 @@
 
 Refer to the [General rules](../general.md) with the following additions:
 
-This competition is for 3D-rendered still images. Use any tool you like (Blender, Maya, Cinema 4D, etc.) - submit the final rendered image.
+This competition is for 3D-rendered still images: the artistic work is done in 3D - modeling, texturing, shading, lighting and rendering. Use any tool you like (Blender, Maya, Cinema 4D, etc.) and submit the final rendered image.
 
 - All scene content must be original and unreleased. No covers, copies, or reproductions of someone else's work.
 - If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.
@@ -13,6 +13,9 @@ This competition is for 3D-rendered still images. Use any tool you like (Blender
 - Submit a version of the final image with NO visible signature. Name this file with "_nosig" prefix. Entries without an unsigned version will be disqualified.
 - Image resolution: 1920x1080
 - Mesh has to be unpublished before the competition deadline
+- **The submitted image must be the rendered output of your 3D scene.** Postprocessing is limited to technical adjustments such as color correction, tone mapping, denoising, and compositing your own render passes.
+- **Painting over the render or adding significant 2D elements is not allowed.** Such an entry belongs in the Digital Graphics compo instead.
+- Include at least one work-in-progress screenshot from your 3D tool's viewport (e.g. wireframe or clay render) in a subdirectory called "unfinished" in the ZIP archive.
 - Submit a `readme.txt` listing tools used and creation process
 - Optionally include source files (Blender, FBX, etc.) under 50 MB
 - The compo time slot determines how many entries can be shown. If there are more entries than fit, a preselection jury will choose which to include.

--- a/summer26/graphics/digital-graphics.md
+++ b/summer26/graphics/digital-graphics.md
@@ -11,10 +11,11 @@ Refer to the [General rules](../general.md) with the following additions:
 - Pictures will be shown in 1920x1080 resolution with full 24-bit color depth.
 - Submit a version of the final image with NO visible signature. Name this file with "_nosig" prefix (e.g. "cool_image.png" for the final image and "cool_image_nosig.png" for unsigned version of the same image). Entries without an unsigned version will be disqualified.
 - A text file named "readme.txt" stating used techniques and sources of any material used in the entry must be submitted.
-- **The entry must be a digital image, with the bulk of the artistic work done in digital tools.** A scan of a finished painting or drawing on its own does not qualify - but scanned material may be used as a base, reference, or element if you build on top of it digitally.
-- **Submit your work to the right compo.** Digital Graphics is for digital painting, digital illustration, vector art, and mixed digital work. If your entry is *primarily* one of the following, submit it to that compo instead:
-  - **Pixel & Oldskool Graphics** - pixel-by-pixel work in low resolution, or native legacy platform formats (C64, Amiga IFF, etc.)
-  - **3D Graphics** - work whose main artistic effort is 3D modeling and rendering
+- **Any digital technique is welcome.** Digital painting, digital illustration, vector art, photomanipulation, 3D renders with paintover or other postprocessing, and any combination of these all belong in this compo.
+- **The bulk of the artistic work must be done in digital tools.** A scan or photo of a finished physical painting or drawing on its own does not qualify - but scanned material may be used as a base, reference, or element if you build on top of it digitally.
+- **Two other compos overlap with this one.** Choose the compo based on how the work was made:
+  - **Pixel & Oldskool Graphics** - if your work is drawn pixel by pixel in low resolution, or made in a native legacy platform format (C64, Amiga IFF, etc.)
+  - **3D Graphics** - if your entry is a 3D render as it comes out of the renderer, without paintover or other significant 2D postprocessing. A painted-over or heavily postprocessed 3D render belongs here in Digital Graphics.
 - The image resolution must be 1920x1080. Feel free to make the image 1080x1920, but due to the letterboxing, it will appear smaller on screen and in the stream as well.
 - You must submit clear evidence of the process of creating the digital graphics competition picture in the form of at least THREE versions of the unfinished picture that show the creation process.
 - This means that the different steps of the process (e.g. outline, coloring, retouching) are shown in different files from different points in time when the picture is being created.

--- a/summer26/rules.html
+++ b/summer26/rules.html
@@ -432,11 +432,12 @@ li.common { color: #888; }
      <li class="common">Pictures will be shown in 1920x1080 resolution with full 24-bit color depth.</li>
      <li>Submit a version of the final image with NO visible signature. Name this file with "_nosig" prefix (e.g. "cool_image.png" for the final image and "cool_image_nosig.png" for unsigned version of the same image). Entries without an unsigned version will be disqualified.</li>
      <li>A text file named "readme.txt" stating used techniques and sources of any material used in the entry must be submitted.</li>
-     <li><strong>The entry must be a digital image, with the bulk of the artistic work done in digital tools.</strong> A scan of a finished painting or drawing on its own does not qualify - but scanned material may be used as a base, reference, or element if you build on top of it digitally.</li>
-     <li><strong>Submit your work to the right compo.</strong> Digital Graphics is for digital painting, digital illustration, vector art, and mixed digital work. If your entry is <em>primarily</em> one of the following, submit it to that compo instead:
+     <li><strong>Any digital technique is welcome.</strong> Digital painting, digital illustration, vector art, photomanipulation, 3D renders with paintover or other postprocessing, and any combination of these all belong in this compo.</li>
+     <li><strong>The bulk of the artistic work must be done in digital tools.</strong> A scan or photo of a finished physical painting or drawing on its own does not qualify - but scanned material may be used as a base, reference, or element if you build on top of it digitally.</li>
+     <li><strong>Two other compos overlap with this one.</strong> Choose the compo based on how the work was made:
 <ul dir="auto">
-     <li><strong>Pixel &amp; Oldskool Graphics</strong> - pixel-by-pixel work in low resolution, or native legacy platform formats (C64, Amiga IFF, etc.)</li>
-     <li><strong>3D Graphics</strong> - work whose main artistic effort is 3D modeling and rendering</li>
+     <li><strong>Pixel &amp; Oldskool Graphics</strong> - if your work is drawn pixel by pixel in low resolution, or made in a native legacy platform format (C64, Amiga IFF, etc.)</li>
+     <li><strong>3D Graphics</strong> - if your entry is a 3D render as it comes out of the renderer, without paintover or other significant 2D postprocessing. A painted-over or heavily postprocessed 3D render belongs here in Digital Graphics.</li>
 </ul>
 </li>
      <li>The image resolution must be 1920x1080. Feel free to make the image 1080x1920, but due to the letterboxing, it will appear smaller on screen and in the stream as well.</li>
@@ -494,7 +495,7 @@ li.common { color: #888; }
 <h2 class="heading-element" dir="auto">3D Graphics</h2>
 </div>
 <p dir="auto">Refer to the General rules with the following additions:</p>
-<p dir="auto">This competition is for 3D-rendered still images. Use any tool you like (Blender, Maya, Cinema 4D, etc.) - submit the final rendered image.</p>
+<p dir="auto">This competition is for 3D-rendered still images: the artistic work is done in 3D - modeling, texturing, shading, lighting and rendering. Use any tool you like (Blender, Maya, Cinema 4D, etc.) and submit the final rendered image.</p>
 <ul dir="auto">
      <li>All scene content must be original and unreleased. No covers, copies, or reproductions of someone else's work.</li>
      <li class="common">If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
@@ -505,6 +506,9 @@ li.common { color: #888; }
      <li>Submit a version of the final image with NO visible signature. Name this file with "_nosig" prefix. Entries without an unsigned version will be disqualified.</li>
      <li>Image resolution: 1920x1080</li>
      <li>Mesh has to be unpublished before the competition deadline</li>
+     <li><strong>The submitted image must be the rendered output of your 3D scene.</strong> Postprocessing is limited to technical adjustments such as color correction, tone mapping, denoising, and compositing your own render passes.</li>
+     <li><strong>Painting over the render or adding significant 2D elements is not allowed.</strong> Such an entry belongs in the Digital Graphics compo instead.</li>
+     <li>Include at least one work-in-progress screenshot from your 3D tool's viewport (e.g. wireframe or clay render) in a subdirectory called "unfinished" in the ZIP archive.</li>
      <li>Submit a <code>readme.txt</code> listing tools used and creation process</li>
      <li>Optionally include source files (Blender, FBX, etc.) under 50 MB</li>
      <li class="common">The compo time slot determines how many entries can be shown. If there are more entries than fit, a preselection jury will choose which to include.</li>

--- a/summer26/rules.html
+++ b/summer26/rules.html
@@ -432,12 +432,11 @@ li.common { color: #888; }
      <li class="common">Pictures will be shown in 1920x1080 resolution with full 24-bit color depth.</li>
      <li>Submit a version of the final image with NO visible signature. Name this file with "_nosig" prefix (e.g. "cool_image.png" for the final image and "cool_image_nosig.png" for unsigned version of the same image). Entries without an unsigned version will be disqualified.</li>
      <li>A text file named "readme.txt" stating used techniques and sources of any material used in the entry must be submitted.</li>
-     <li><strong>Any digital technique is welcome.</strong> Digital painting, digital illustration, vector art, photomanipulation, 3D renders with paintover or other postprocessing, and any combination of these all belong in this compo.</li>
-     <li><strong>The bulk of the artistic work must be done in digital tools.</strong> A scan or photo of a finished physical painting or drawing on its own does not qualify - but scanned material may be used as a base, reference, or element if you build on top of it digitally.</li>
-     <li><strong>Two other compos overlap with this one.</strong> Choose the compo based on how the work was made:
+     <li><strong>The entry must be a digital image, with the bulk of the artistic work done in digital tools.</strong> A scan of a finished painting or drawing on its own does not qualify - but scanned material may be used as a base, reference, or element if you build on top of it digitally.</li>
+     <li><strong>Submit your work to the right compo.</strong> Digital Graphics is for digital painting, digital illustration, vector art, and mixed digital work. If your entry is <em>primarily</em> one of the following, submit it to that compo instead:
 <ul dir="auto">
-     <li><strong>Pixel &amp; Oldskool Graphics</strong> - if your work is drawn pixel by pixel in low resolution, or made in a native legacy platform format (C64, Amiga IFF, etc.)</li>
-     <li><strong>3D Graphics</strong> - if your entry is a 3D render as it comes out of the renderer, without paintover or other significant 2D postprocessing. A painted-over or heavily postprocessed 3D render belongs here in Digital Graphics.</li>
+     <li><strong>Pixel &amp; Oldskool Graphics</strong> - pixel-by-pixel work in low resolution, or native legacy platform formats (C64, Amiga IFF, etc.)</li>
+     <li><strong>3D Graphics</strong> - work whose main artistic effort is 3D modeling and rendering</li>
 </ul>
 </li>
      <li>The image resolution must be 1920x1080. Feel free to make the image 1080x1920, but due to the letterboxing, it will appear smaller on screen and in the stream as well.</li>
@@ -495,7 +494,7 @@ li.common { color: #888; }
 <h2 class="heading-element" dir="auto">3D Graphics</h2>
 </div>
 <p dir="auto">Refer to the General rules with the following additions:</p>
-<p dir="auto">This competition is for 3D-rendered still images: the artistic work is done in 3D - modeling, texturing, shading, lighting and rendering. Use any tool you like (Blender, Maya, Cinema 4D, etc.) and submit the final rendered image.</p>
+<p dir="auto">This competition is for 3D-rendered still images. Use any tool you like (Blender, Maya, Cinema 4D, etc.) - submit the final rendered image.</p>
 <ul dir="auto">
      <li>All scene content must be original and unreleased. No covers, copies, or reproductions of someone else's work.</li>
      <li class="common">If you use Creative Commons or Public Domain material, state so in your entry form and cite the source.</li>
@@ -506,9 +505,6 @@ li.common { color: #888; }
      <li>Submit a version of the final image with NO visible signature. Name this file with "_nosig" prefix. Entries without an unsigned version will be disqualified.</li>
      <li>Image resolution: 1920x1080</li>
      <li>Mesh has to be unpublished before the competition deadline</li>
-     <li><strong>The submitted image must be the rendered output of your 3D scene.</strong> Postprocessing is limited to technical adjustments such as color correction, tone mapping, denoising, and compositing your own render passes.</li>
-     <li><strong>Painting over the render or adding significant 2D elements is not allowed.</strong> Such an entry belongs in the Digital Graphics compo instead.</li>
-     <li>Include at least one work-in-progress screenshot from your 3D tool's viewport (e.g. wireframe or clay render) in a subdirectory called "unfinished" in the ZIP archive.</li>
      <li>Submit a <code>readme.txt</code> listing tools used and creation process</li>
      <li>Optionally include source files (Blender, FBX, etc.) under 50 MB</li>
      <li class="common">The compo time slot determines how many entries can be shown. If there are more entries than fit, a preselection jury will choose which to include.</li>


### PR DESCRIPTION
Feedback from Tomi (2026-06-08): the "submit it to that compo instead" wording in Digital Graphics read as if 3D-based and painted-over works were excluded, and 3D Graphics said nothing about the allowed level of postprocessing.

## Digital Graphics
- New rule: **any digital technique is welcome** - digital painting, illustration, vector art, photomanipulation, 3D renders with paintover/postprocessing, and any combination.
- The only hard exclusion stays: a plain scan/photo of a finished physical painting (digital base building still allowed).
- The compo overlap is now explained by *how the work was made* instead of the vague "primarily": pixel-by-pixel / legacy format goes to Pixel & Oldskool, a raw render goes to 3D.

## 3D Graphics
- The entry must be **the rendered output of your 3D scene**; postprocessing limited to technical adjustments (color correction, tone mapping, denoising, compositing your own render passes).
- Paintover or significant 2D elements are explicitly not allowed - that entry belongs in Digital Graphics. This makes the boundary one clean line, same spirit as Revision's split.
- Added a viewport WIP screenshot requirement (wireframe or clay render in `unfinished/`) as process evidence, mirroring the stage requirements in the other graphics compos.

`rules.html` will be updated separately when this is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)